### PR TITLE
Add SSR support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,6 +13,18 @@ var _utils = require("./utils");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
 var FootnotesContext = /*#__PURE__*/_react["default"].createContext({});
 
 var FootnoteRef = function FootnoteRef(props) {
@@ -39,13 +51,24 @@ var FootnoteRef = function FootnoteRef(props) {
       idNote: idNote,
       description: description
     };
-  }, [idRef, idNote, description]);
+  }, [idRef, idNote, description]); // It is not possible to update the React state on the server, still the
+  // footnote references need to be registered so the footnotes can be rendered.
+  // In that case, we mutate the state directly so the footnotes work with SSR.
 
-  if (!footnotes.current.find(function (fn) {
-    return fn.idRef === footnote.ref;
-  })) {
-    footnotes.current.push(footnote);
-  }
+
+  if (!footnotes.has(footnote.idRef)) {
+    footnotes.set(footnote.idRef, footnote);
+  } // Once the application mounts, the footnotes state has been emptied and we
+  // can properly register the current footnote in it, and unregister it if it
+  // was to unmount.
+
+
+  _react["default"].useEffect(function () {
+    var unregister = register(footnote);
+    return function () {
+      return unregister();
+    };
+  }, [register, footnote]);
 
   return /*#__PURE__*/_react["default"].createElement("a", {
     className: props.className,
@@ -75,7 +98,8 @@ var Footnotes = function Footnotes(props) {
       List = props.List,
       ListItem = props.ListItem,
       BackLink = props.BackLink;
-  if (footnotes.current.length === 0) return null;
+  if (footnotes.size === 0) return null;
+  var references = Array.from(footnotes.values());
   return /*#__PURE__*/_react["default"].createElement(Wrapper, {
     "data-a11y-footnotes-footer": true,
     role: "doc-endnotes"
@@ -84,7 +108,7 @@ var Footnotes = function Footnotes(props) {
     id: footnotesTitleId
   }), /*#__PURE__*/_react["default"].createElement(List, {
     "data-a11y-footnotes-list": true
-  }, footnotes.current.map(function (_ref, index) {
+  }, references.map(function (_ref, index) {
     var idNote = _ref.idNote,
         idRef = _ref.idRef,
         description = _ref.description;
@@ -119,7 +143,10 @@ var FootnotesProvider = function FootnotesProvider(_ref2) {
   var children = _ref2.children,
       footnotesTitleId = _ref2.footnotesTitleId;
 
-  var footnotes = _react["default"].useRef([]);
+  var _React$useState = _react["default"].useState(new Map()),
+      _React$useState2 = _slicedToArray(_React$useState, 2),
+      footnotes = _React$useState2[0],
+      setFootnotes = _React$useState2[1];
 
   var getBaseId = _react["default"].useCallback(function (_ref3) {
     var id = _ref3.id,
@@ -133,7 +160,31 @@ var FootnotesProvider = function FootnotesProvider(_ref2) {
 
   var getFootnoteId = _react["default"].useCallback(function (props) {
     return getBaseId(props) + '-note';
-  }, [getBaseId]);
+  }, [getBaseId]); // When JavaScript kicks in and the application mounts, reset the footnotes
+  // store which was mutated by every reference.
+
+
+  _react["default"].useEffect(function () {
+    return setFootnotes(new Map());
+  }, []);
+
+  var register = _react["default"].useCallback(function (footnote) {
+    setFootnotes(function (footnotes) {
+      var clone = new Map(footnotes);
+      if (!clone.has(footnote.idRef)) clone.set(footnote.ifRef, footnote);
+      return clone;
+    }); // Return a function which can be used to unregister the footnote. This
+    // makes it convenient to register a footnote reference on mount, and
+    // unregister it on unmount.
+
+    return function () {
+      setFootnotes(function (footnotes) {
+        var clone = new Map(footnotes);
+        clone["delete"](footnote.idRef);
+        return clone;
+      });
+    };
+  }, []);
 
   return /*#__PURE__*/_react["default"].createElement(FootnotesContext.Provider, {
     value: {
@@ -141,7 +192,7 @@ var FootnotesProvider = function FootnotesProvider(_ref2) {
       footnotesTitleId: footnotesTitleId,
       getFootnoteRefId: getFootnoteRefId,
       getFootnoteId: getFootnoteId,
-      register: addFootnote
+      register: register
     }
   }, children);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,24 +13,13 @@ var _utils = require("./utils");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
 var FootnotesContext = /*#__PURE__*/_react["default"].createContext({});
 
 var FootnoteRef = function FootnoteRef(props) {
   var description = props.description;
 
   var _React$useContext = _react["default"].useContext(FootnotesContext),
+      footnotes = _React$useContext.footnotes,
       footnotesTitleId = _React$useContext.footnotesTitleId,
       getFootnoteRefId = _React$useContext.getFootnoteRefId,
       getFootnoteId = _React$useContext.getFootnoteId,
@@ -52,9 +41,11 @@ var FootnoteRef = function FootnoteRef(props) {
     };
   }, [idRef, idNote, description]);
 
-  _react["default"].useEffect(function () {
-    return register(footnote);
-  }, [register, footnote]);
+  if (!footnotes.current.find(function (fn) {
+    return fn.idRef === footnote.ref;
+  })) {
+    footnotes.current.push(footnote);
+  }
 
   return /*#__PURE__*/_react["default"].createElement("a", {
     className: props.className,
@@ -84,7 +75,7 @@ var Footnotes = function Footnotes(props) {
       List = props.List,
       ListItem = props.ListItem,
       BackLink = props.BackLink;
-  if (footnotes.length === 0) return null;
+  if (footnotes.current.length === 0) return null;
   return /*#__PURE__*/_react["default"].createElement(Wrapper, {
     "data-a11y-footnotes-footer": true,
     role: "doc-endnotes"
@@ -93,7 +84,7 @@ var Footnotes = function Footnotes(props) {
     id: footnotesTitleId
   }), /*#__PURE__*/_react["default"].createElement(List, {
     "data-a11y-footnotes-list": true
-  }, footnotes.map(function (_ref, index) {
+  }, footnotes.current.map(function (_ref, index) {
     var idNote = _ref.idNote,
         idRef = _ref.idRef,
         description = _ref.description;
@@ -128,18 +119,7 @@ var FootnotesProvider = function FootnotesProvider(_ref2) {
   var children = _ref2.children,
       footnotesTitleId = _ref2.footnotesTitleId;
 
-  var _React$useState = _react["default"].useState([]),
-      _React$useState2 = _slicedToArray(_React$useState, 2),
-      footnotes = _React$useState2[0],
-      setFootnotes = _React$useState2[1];
-
-  var addFootnote = _react["default"].useCallback(function (footnote) {
-    setFootnotes(function (footnotes) {
-      return footnotes.filter(function (f) {
-        return f.idRef !== footnote.idRef;
-      }).concat(footnote);
-    });
-  }, []);
+  var footnotes = _react["default"].useRef([]);
 
   var getBaseId = _react["default"].useCallback(function (_ref3) {
     var id = _ref3.id,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const FootnotesContext = React.createContext({})
 export const FootnoteRef = props => {
   const { description } = props
   const {
+    footnotes,
     footnotesTitleId,
     getFootnoteRefId,
     getFootnoteId,
@@ -26,7 +27,9 @@ export const FootnoteRef = props => {
     description,
   ])
 
-  React.useEffect(() => register(footnote), [register, footnote])
+  if (!footnotes.current.find(fn => fn.idRef === footnote.ref)) {
+    footnotes.current.push(footnote)
+  }
 
   return (
     <a
@@ -53,13 +56,13 @@ export const Footnotes = props => {
   const { footnotes, footnotesTitleId } = React.useContext(FootnotesContext)
   const { Wrapper, Title, List, ListItem, BackLink } = props
 
-  if (footnotes.length === 0) return null
+  if (footnotes.current.length === 0) return null
 
   return (
     <Wrapper data-a11y-footnotes-footer role='doc-endnotes'>
       <Title data-a11y-footnotes-title id={footnotesTitleId} />
       <List data-a11y-footnotes-list>
-        {footnotes.map(({ idNote, idRef, description }, index) => (
+        {footnotes.current.map(({ idNote, idRef, description }, index) => (
           <ListItem
             id={idNote}
             key={idNote}
@@ -89,12 +92,7 @@ Footnotes.defaultProps = {
 }
 
 export const FootnotesProvider = ({ children, footnotesTitleId }) => {
-  const [footnotes, setFootnotes] = React.useState([])
-  const addFootnote = React.useCallback(footnote => {
-    setFootnotes(footnotes =>
-      footnotes.filter(f => f.idRef !== footnote.idRef).concat(footnote)
-    )
-  }, [])
+  const footnotes = React.useRef([])
   const getBaseId = React.useCallback(
     ({ id, children }) => id || getIdFromTree(children),
     []

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ export const FootnoteRef = props => {
     footnotesTitleId,
     getFootnoteRefId,
     getFootnoteId,
-    register,
   } = React.useContext(FootnotesContext)
   const idRef = React.useMemo(() => getFootnoteRefId(props), [
     getFootnoteRefId,
@@ -27,9 +26,7 @@ export const FootnoteRef = props => {
     description,
   ])
 
-  if (!footnotes.current.find(fn => fn.idRef === footnote.ref)) {
-    footnotes.current.push(footnote)
-  }
+  if (!footnotes.has(footnote.idRef)) footnotes.set(footnote.idRef, footnote)
 
   return (
     <a
@@ -56,13 +53,15 @@ export const Footnotes = props => {
   const { footnotes, footnotesTitleId } = React.useContext(FootnotesContext)
   const { Wrapper, Title, List, ListItem, BackLink } = props
 
-  if (footnotes.current.length === 0) return null
+  if (footnotes.size === 0) return null
+
+  const references = Array.from(footnotes.values())
 
   return (
     <Wrapper data-a11y-footnotes-footer role='doc-endnotes'>
       <Title data-a11y-footnotes-title id={footnotesTitleId} />
       <List data-a11y-footnotes-list>
-        {footnotes.current.map(({ idNote, idRef, description }, index) => (
+        {references.map(({ idNote, idRef, description }, index) => (
           <ListItem
             id={idNote}
             key={idNote}
@@ -92,7 +91,7 @@ Footnotes.defaultProps = {
 }
 
 export const FootnotesProvider = ({ children, footnotesTitleId }) => {
-  const footnotes = React.useRef([])
+  const footnotes = React.useRef(new Map())
   const getBaseId = React.useCallback(
     ({ id, children }) => id || getIdFromTree(children),
     []
@@ -108,11 +107,10 @@ export const FootnotesProvider = ({ children, footnotesTitleId }) => {
   return (
     <FootnotesContext.Provider
       value={{
-        footnotes,
+        footnotes: footnotes.current,
         footnotesTitleId,
         getFootnoteRefId,
         getFootnoteId,
-        register: addFootnote,
       }}
     >
       {children}


### PR DESCRIPTION
The library works like this: there is an outer context (issued via the `FootnotesProvider` component). Then every *footnote reference* being rendered within that context (with the `FootnoteRef` component) is tracked, in the correct order. From this collection of references can be automatically generated the actual *footnotes* (the `Footnotes` component), at the bottom of the page. See [the example](https://github.com/KittyGiraudel/react-a11y-footnotes#example) for more details.


## Current problem

In the current version, the footnote references register themselves within the context when mounting:

https://github.com/KittyGiraudel/react-a11y-footnotes/blob/5ddb1aa4602c82ea8e0d5504f45b37f4fa3322ba/src/index.js#L29

The problem is that it of course doesn’t work with server-side rendering because `React.useEffect()` does not fire on the server. As a result, the footnote references are being rendered correctly, but they don’t link to anything because no footnotes are effectively recorded in the context.

## Suggested solution

This pull-request replaces the state provided through the context with a React ref so it works on the server. So instead of having a `footnotes` array in the local state and passing it down (and its setter) to the `FootnotesContext` context, the `FootnotesProvider` initialises an empty map in a React ref, and passes that ref down. 

🤔 Now what I’m not sure about is whether having this ref being mutated in the render method of every footnote reference is a good idea. Basically if they don’t find themselves already in the array, they push themselves in it. It feels a little shady having to do that in the render method.

I’m open to suggestions. :)

---

The current (state) implementation can be played with here: https://codesandbox.io/s/footnotes-v34hm
The new (ref) implementation can be played with here: https://codesandbox.io/s/footnotes-forked-e3t4f