### PR TITLE
Adding types to files section

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "Kitty Giraudel (https://kittygiraudel.com)",
   "files": [
     "dist/index.js",
-    "dist/styles.css"
+    "dist/styles.css",
+    "dist/index.d.ts"
   ],
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Adding types to files section in package.json in order to include it then publishing. It wasn't included in version 0.5.0.