### PR TITLE
Fix typo in “Without a bundler” styles path

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ import 'react-a11y-footnotes/dist/styles.css'
 If you’re not using a bundler you can find the styles at:
 
 ```
-your-app/node_modules/react-a11y-foonotes/dist/styles.css
+your-app/node_modules/react-a11y-footnotes/dist/styles.css
 ```
 
 Include this file however you include the rest of your stylesheets. Alternatively, you can use a CDN like Unpkg, but this is not recommended for production apps.


### PR DESCRIPTION
Noticed this when I copied and pasted it and was scratching my head why it wasn’t working for a few minutes. 😅 