### PR TITLE
Fixing react defaultProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,9 +62,14 @@ FootnoteRef.propTypes = {
   id: PropTypes.string,
 }
 
-export const Footnotes = props => {
+export const Footnotes = ({
+  Wrapper = 'footer',
+  Title = props => <h2 {...props}>Footnotes</h2>,
+  List = 'ol',
+  ListItem = 'li',
+  BackLink = props => <a {...props}>↩</a>,
+}) => {
   const { footnotes, footnotesTitleId } = React.useContext(FootnotesContext)
-  const { Wrapper, Title, List, ListItem, BackLink } = props
 
   if (footnotes.size === 0) return null
 
@@ -75,11 +80,7 @@ export const Footnotes = props => {
       <Title data-a11y-footnotes-title id={footnotesTitleId} />
       <List data-a11y-footnotes-list>
         {references.map(({ idNote, idRef, description }, index) => (
-          <ListItem
-            id={idNote}
-            key={idNote}
-            data-a11y-footnotes-list-item
-          >
+          <ListItem id={idNote} key={idNote} data-a11y-footnotes-list-item>
             {description}&nbsp;
             <BackLink
               data-a11y-footnotes-back-link
@@ -94,15 +95,10 @@ export const Footnotes = props => {
   )
 }
 
-Footnotes.defaultProps = {
-  Wrapper: 'footer',
-  Title: props => <h2 {...props}>Footnotes</h2>,
-  List: 'ol',
-  ListItem: 'li',
-  BackLink: props => <a {...props}>↩</a>,
-}
-
-export const FootnotesProvider = ({ children, footnotesTitleId }) => {
+export const FootnotesProvider = ({
+  children,
+  footnotesTitleId = 'footnotes-label',
+}) => {
   const [footnotes, setFootnotes] = React.useState(new Map())
   const getBaseId = React.useCallback(
     ({ id, children }) => id || getIdFromTree(children),
@@ -153,10 +149,6 @@ export const FootnotesProvider = ({ children, footnotesTitleId }) => {
       {children}
     </FootnotesContext.Provider>
   )
-}
-
-FootnotesProvider.defaultProps = {
-  footnotesTitleId: 'footnotes-label',
 }
 
 function getTextFromTree(tree) {


### PR DESCRIPTION
Related #265 
This pull request includes several changes to the `src/index.js` file, primarily focusing on refactoring the `Footnotes` and `FootnotesProvider` components. The most important changes include the introduction of default component parameters, removal of defaultProps, and refactoring for cleaner code.

Refactoring components:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L65-L67): Introduced default component parameters for `Footnotes` (`Wrapper`, `Title`, `List`, `ListItem`, `BackLink`) to replace the use of `defaultProps`.
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L97-R101): Removed `defaultProps` from `Footnotes` and `FootnotesProvider`, as default parameters are now used directly in the function signatures. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L97-R101) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L158-L161)

Code simplification:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L78-R83): Simplified the `Footnotes` component by directly destructuring the default component parameters and removing the redundant `props` parameter. 